### PR TITLE
bumps base python docker image to 2.7.13

### DIFF
--- a/Dockerfile-client
+++ b/Dockerfile-client
@@ -1,10 +1,10 @@
-FROM python:2.7.10
+FROM python:2.7.13
 
 # File Author / Maintainer
 MAINTAINER Sushma Thimmappa(sushma.kyasaralli.thimmappa@intel.com)
 
 # Update the sources list
-RUN apt-get update && apt-get install -y sudo 
+RUN apt-get update && apt-get install -y sudo
 
 # Install basic applications
 RUN apt-get install -y tar git curl wget vim
@@ -12,29 +12,29 @@ RUN apt-get install -y tar git curl wget vim
 # Install Python and Basic Python Tools
 RUN apt-get install -y  python-dev python-distribute python-pip
 
-#Upgrade pip
-#RUN pip install --upgrade pip --proxy=http://proxy-addr:port
-RUN pip install --upgrade pip 
+# Upgrade pip
+# proxy settings example RUN pip install --upgrade pip --proxy=http://proxy-addr:port
+RUN pip install --upgrade pip
 
-#Install pip packages
-#proxy settings example RUN pip install numpy --proxy=http://proxy-addr:port
-RUN pip install numpy 
-  
+# Install pip packages
+# proxy settings example RUN pip install numpy --proxy=http://proxy-addr:port
+RUN pip install numpy
+
 RUN pip install requests && pip install eventlet &&  pip install matplotlib
 
-#Create a user to be able to run client commands
+# Create a user to be able to run client commands
 RUN useradd -m clientuser && echo "clientuser:12345"|chpasswd && adduser clientuser sudo
 
-#Move to user's dir as current working directory
+# Move to user's dir as current working directory
 WORKDIR /home/clientuser
 
-#Copy the client related files to the container
+# Copy the client related files to the container
 ADD Node-DC-EIS-client /home/clientuser/Node-DC-EIS-client/
 
-#Setting user permissions for the files
+# Setting user permissions for the files
 RUN chown -R clientuser:clientuser /home/clientuser/Node-DC-EIS-client
 
-#Switch to user (was root until now)
+# Switch to user (was root until now)
 USER clientuser
 
 EXPOSE 80


### PR DESCRIPTION
This bumps the base docker image from 2.7.10 to 2.7.13. Prior to doing so, I was having issues with with python-tk, which this benchmark depends on. Bumping to the latest Python 2.7 docker image fixed this and I am now able to successfully run the test.

I also cleaned up the comments to make them consistent with each other while I was in there. Hope that's OK, let me know if you want me to back those changes out of this.