### PR TITLE
Fix to address database connection error.

### DIFF
--- a/Node-DC-EIS-client/process_time_based_output.py
+++ b/Node-DC-EIS-client/process_time_based_output.py
@@ -21,9 +21,6 @@ import numpy as np
 import operator
 import requests
 import json
-import matplotlib
-matplotlib.use(matplotlib.get_backend())
-import matplotlib.pyplot as plt
 import util
 import math
 from collections import Counter
@@ -231,6 +228,10 @@ def post_process(temp_log,output_file,results_dir,interval,memlogfile,no_graph):
   processed_file.flush()
 
   if not no_graph:
+    import matplotlib
+    matplotlib.use(matplotlib.get_backend())
+    import matplotlib.pyplot as plt
+
     #plot graphs. Plots three graphs, latency graph, throughput graph and a memory usage graph. These files are stored in the result directory  
     print ("[%s] Plotting graphs." % (util.get_current_time()))
     #write_arr = list(range(int(abs_start), int(end_time), interval))

--- a/Node-DC-EIS-client/runspec.py
+++ b/Node-DC-EIS-client/runspec.py
@@ -31,9 +31,6 @@ import time
 import traceback
 import urlparse
 from urlparse import urlsplit
-import matplotlib
-matplotlib.use(matplotlib.get_backend())
-import matplotlib.pyplot as plt
 from collections import OrderedDict 
 from collections import Counter
 from datetime import datetime
@@ -1316,6 +1313,10 @@ def plot_graph_request_based_run(output_file):
   # Input : Output file
   # Output: All resulted files will be stored in the result directory
   """
+  import matplotlib
+  matplotlib.use(matplotlib.get_backend())
+  import matplotlib.pyplot as plt
+
   start_time = []
   response_time = []
   rps = []

--- a/Node-DC-EIS-cluster/server-cluster.js
+++ b/Node-DC-EIS-cluster/server-cluster.js
@@ -40,8 +40,9 @@ function startSingleNodeInstance() {
   mongoose.connect(appConfig.db_url);
   var db = mongoose.connection;
 
-  db.on('error', function() {
+  db.on('error', function(err) {
     // connection error!
+    console.log(err.message);
     console.log('Mongoose connection error. Server exiting');
     process.exit(0);
   });


### PR DESCRIPTION
1) Refactored runspec and process_time_based_output by moving matplotlib import in the function. This import is unnecessary when user invoke client with --nograph option.

2) Handle database connection error with appropriate error message instead of generic db server error.