### PR TITLE
Socket call has default setting of 'keepalive' causing socket connection error

### DIFF
--- a/Node-DC-EIS-client/node_dc_eis_testurls.py
+++ b/Node-DC-EIS-client/node_dc_eis_testurls.py
@@ -112,6 +112,7 @@ def get_url(url, url_type, request_num, log, phase, accept_header):
 Host: {}
 User-Agent: runspec/0.9
 Accept: {}
+Connection: close
 
 '''.format(req_path, urlo.netloc, accept_header)
 


### PR DESCRIPTION
Before the change:
====Validation and Error Summary====
Timeout Error = 0
Connection Error = 26333
Http Error = 0
Bad Url Error = 0
Static posts = 0

After the change:
====Validation and Error Summary====
Timeout Error = 0
Connection Error = 0
Http Error = 0
Bad Url Error = 0
Static posts = 0
This should fix issue https://github.com/Node-DC/Node-DC-EIS/issues/61
