### PR TITLE
Added npm scripts to automate running the workload

### DIFF
--- a/Node-DC-EIS-cluster/automation.js
+++ b/Node-DC-EIS-cluster/automation.js
@@ -1,0 +1,81 @@
+
+/*
+ Copyright (c) 2017 Intel Corporation 
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+var _spawn = require('cross-spawn');
+var Promise = require('bluebird');
+var _waitOn = Promise.promisify(require('wait-on'));
+
+var _config = require('./config/configuration.js');
+
+var env = process.env;
+
+function npmRun(args) {
+  return _spawn(env.npm_node_execpath,
+    [env.npm_execpath, '-s', 'run'].concat(args),
+    {stdio: 'inherit'});
+}
+
+function npmRunSync(args) {
+  return _spawn.sync(env.npm_node_execpath,
+    [env.npm_execpath, '-s', 'run'].concat(args),
+    { stdio: 'inherit' });
+}
+
+
+children = [];
+
+function killChildren() {
+  children.forEach(function(cc) {
+    cc.kill();
+  });
+}
+
+var mongoPort = '27017';
+if(_config.db_url) {
+  var match = _config.db_url.match(new RegExp('mongodb://([^/]+)/'));
+  if(match.length > 1 && match[1]) {
+    mongoPort = match[1];
+  }
+}
+
+var npm_event = env.npm_lifecycle_event.split(':');
+
+var node_env = (npm_event.length > 1 && npm_event[1]) ? npm_event[1] : 'prod';
+
+children.push(npmRun('mongodb'));
+_waitOn({
+  resources: [
+    'tcp:' + mongoPort
+  ]
+}).then(function() {
+  children.push(npmRun('server:' + node_env));
+  return _waitOn({
+      resources: [
+        'http://' + (_config.app_host || 'localhost') + ':' +
+        (_config.app_port || '9000') +'/'
+      ]
+    });
+}).then(function() {
+  npmRunSync('runspec');
+}).catch(function(err) {
+  killChildren();
+  console.error(err);
+  process.exit(1);
+}).then(function() {
+  killChildren();
+  process.exit(0);
+});

--- a/Node-DC-EIS-cluster/package.json
+++ b/Node-DC-EIS-cluster/package.json
@@ -25,8 +25,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "async": "^2.0.1",
+    "bluebird": "^3.5.1",
     "body-parser": "^1.15.0",
     "cross-env": "^5.1.0",
+    "cross-spawn": "^5.1.0",
     "express": "^4.13.3",
     "lru-cache": "^4.0.1",
     "mkdirp": "^0.5.1",

--- a/Node-DC-EIS-cluster/package.json
+++ b/Node-DC-EIS-cluster/package.json
@@ -8,8 +8,14 @@
     "url": "git://github.com/Node-DC/Node-DC-EIS.git"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server-cluster.js"
+    "server": "npm -s run server:prod",
+    "server:prod": "cross-env NODE_ENV=production node server-cluster.js",
+    "server:dev": "cross-env NODE_ENV=development node server-cluster.js",
+    "mongodb": "mkdirp ../mongodata && numactl --interleave=all mongod --dbpath ../mongodata",
+    "runspec": "cd ../Node-DC-EIS-client && python2 runspec.py -f config.json",
+    "start": "npm -s run start:prod",
+    "start:prod": "node automation.js",
+    "start:dev": "node automation.js"
   },
   "author": "Uttam C Pawar <uttam.c.pawar@intel.com>",
   "contributors": [
@@ -20,10 +26,13 @@
   "dependencies": {
     "async": "^2.0.1",
     "body-parser": "^1.15.0",
+    "cross-env": "^5.1.0",
     "express": "^4.13.3",
     "lru-cache": "^4.0.1",
+    "mkdirp": "^0.5.1",
     "mongoose": "4.4.12",
-    "pug": "^2.0.0-rc.1"
+    "pug": "^2.0.0-rc.1",
+    "wait-on": "^2.0.2"
   },
   "devDependencies": {},
   "keywords": [


### PR DESCRIPTION
I have added npm scripts to the package.json to start the server, mongodb, runspec, and everything at the same time with default setting. This should increase usability of the workload. All these changes also work in windows.

npm scripts:
* `npm run server`: starts nodejs server
* `rpm run mongodb`: creates a "mongodata" folder under the parent and starts mongodb in it
* `rpm run runspec`: starts runspec
* `npm run start` or `npm start`: all of the above at the same time

Note that this defaults to NODE_ENV=production, if you run in development mode, use `npm run server:dev` or `npm run start:dev`