### PR TITLE
Fix: microservices Bad URL Error

### DIFF
--- a/Node-DC-EIS-microservices/db_loader_service/controllers/loader.js
+++ b/Node-DC-EIS-microservices/db_loader_service/controllers/loader.js
@@ -186,6 +186,19 @@ exports.initDb = function initDB(req, res) {
   var lastname_current_index=0;
   var employee_id;
   var employeeObj;
+  original_lname_len = lnames.length;
+  if(original_lname_len <= lastnamecount) {
+    var new_namecount = lastnamecount - original_lname_len;
+    var idx = 0;
+    for (var ii = 0; ii < new_namecount; ii++) {
+      var new_name = lnames[idx]+ii.toString();
+      idx++;
+      if (idx > original_lname_len) {
+        idx = 0;
+      }
+      lnames.push(new_name);
+    }
+  }
   for (var ii=0; ii < count; ii++) {
     async.series([
       function(callback) {


### PR DESCRIPTION
When running in microservices mode the client receives the error
400: Bad URL localhost:3000/employees

This looks to be caused by posts to addNewEmployee being made without
a last name for the employee.

Add logic similar to loader.js from monolithic code to db_loader_service/controllers/loader.js
to ensure enough last names for all the users to be added.

Fixes: #78