### PR TITLE
Fix: #85 - Exiting execution if MongoDB cannot run at predefined port.

### DIFF
--- a/start-server.sh
+++ b/start-server.sh
@@ -62,6 +62,7 @@ if [ -f server-input.txt ]; then
     done
 else
   echo "Expected - mongodb to be running at the port specified in server config"
+  exit 1
 fi
 echo "Installing npm modules"
 npm install


### PR DESCRIPTION
In start-server.sh, one should call exit if [ -f server-input.txt ];
expands in false. Now, this is corrected on the else branch, of course.