### PR TITLE
Changing mongoose from 4.4.12 to 5.7.7 due to security issues.

### DIFF
--- a/Node-DC-EIS-cluster/package.json
+++ b/Node-DC-EIS-cluster/package.json
@@ -22,7 +22,7 @@
     "body-parser": "1.15.0",
     "express": "4.13.3",
     "lru-cache": "4.0.1",
-    "mongoose": "4.4.12",
+    "mongoose": "5.7.7",
     "pug": "2.0.0-rc.1"
   },
   "devDependencies": {},

--- a/Node-DC-EIS-microservices/address_service/package.json
+++ b/Node-DC-EIS-microservices/address_service/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "body-parser": "^1.15.0",
     "express": "^4.13.3",
-    "mongoose": "4.4.12"
+    "mongoose": "5.7.7"
   },
   "devDependencies": {},
   "keywords": [

--- a/Node-DC-EIS-microservices/comp_service/package.json
+++ b/Node-DC-EIS-microservices/comp_service/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "body-parser": "^1.15.0",
     "express": "^4.13.3",
-    "mongoose": "4.4.12"
+    "mongoose": "5.7.7"
   },
   "devDependencies": {},
   "keywords": [

--- a/Node-DC-EIS-microservices/db_loader_service/package.json
+++ b/Node-DC-EIS-microservices/db_loader_service/package.json
@@ -17,7 +17,7 @@
     "async": "^2.0.1",
     "body-parser": "^1.15.0",
     "express": "^4.13.3",
-    "mongoose": "4.4.12"
+    "mongoose": "5.7.7"
   },
   "devDependencies": {},
   "keywords": [

--- a/Node-DC-EIS-microservices/employee_service/package.json
+++ b/Node-DC-EIS-microservices/employee_service/package.json
@@ -17,7 +17,7 @@
     "async": "^2.0.1",
     "body-parser": "^1.15.0",
     "express": "^4.13.3",
-    "mongoose": "4.4.12",
+    "mongoose": "5.7.7",
     "request": "^2.75.0"
   },
   "devDependencies": {},

--- a/Node-DC-EIS-microservices/family_service/package.json
+++ b/Node-DC-EIS-microservices/family_service/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "body-parser": "^1.15.0",
     "express": "^4.13.3",
-    "mongoose": "4.4.12"
+    "mongoose": "5.7.7"
   },
   "devDependencies": {},
   "keywords": [

--- a/Node-DC-EIS-microservices/health_service/package.json
+++ b/Node-DC-EIS-microservices/health_service/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "body-parser": "^1.15.0",
     "express": "^4.13.3",
-    "mongoose": "4.4.12"
+    "mongoose": "5.7.7"
   },
   "devDependencies": {},
   "keywords": [

--- a/Node-DC-EIS-microservices/photo_service/package.json
+++ b/Node-DC-EIS-microservices/photo_service/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "body-parser": "^1.15.0",
     "express": "^4.13.3",
-    "mongoose": "4.4.12"
+    "mongoose": "5.7.7"
   },
   "devDependencies": {},
   "keywords": [


### PR DESCRIPTION
The upgrade solved the mongoose related security issues. These issues are detected with npm audit. Please find attached audits for the Node-DC-EIS-cluster directory:

[branch_audit.txt](https://github.com/Node-DC/Node-DC-EIS/files/3843972/branch_audit.txt)
[master_audit.txt](https://github.com/Node-DC/Node-DC-EIS/files/3843973/master_audit.txt)

Moreover, I would like to mention that the services in Node-DC-EIS-microservices manigested the security issues related to mongoose before the change. Now, at the level of services, there are no security issues detected by audit.